### PR TITLE
fix(audio): toggle button + roadmap restructure

### DIFF
--- a/docs/IDEES.md
+++ b/docs/IDEES.md
@@ -1,91 +1,137 @@
-# Toutes nouvelles idées
+# ROADMAP — Collectif Feydeau
 
-# Priorités actuelles
+> Anciennes "Toutes nouvelles idées". Repackagé en roadmap priorisée avec contexte technique.
+> Mise à jour : 2026-05-22.
 
-### GESTION DES DONNEES
+---
 
- le bouton bruitage quand on reclique dessus il ne s'éteint pas 
-on a plus le bouton marqué comme visiter et avec tous les boutons il reste pas beaucoup de place 
-- [X] **rajouter les MP3** : 
-- [ ] **rajouter les images** : 
-  12 allée Duguay-Trouin / 22 rue Kervégan
-  9-10 allée Duguay-Trouin / 16-18 rue Kervégan 
-- [ ] **Mise à jour** : Récupérer les informations depuis Google sheet
-- [ ] **Mise à jour** : Exporter les informations pour les copier sur OpenAgenda facilement
-- [ ] **Images d'événements principaux** : 5-10 événements phares (400x300px, <50KB)
+## ✅ Récemment livré
 
-### "Carte au Trésor"
+- [x] Sync programme depuis Google Sheets (events + artists) — PR `feat/remote-program-sync` (en attente merge).
+- [x] Image entière sur "Histoire des lieux" (fix `cover` → `object-contain`) — PR `fix/location-history-photo-full`.
+- [x] Photos 12 et 9-10 allée Duguay-Trouin (PR #2 mergée).
+- [x] MP3 audioguides ajoutés.
+- [x] Fix bouton bruitage : reclic ne s'éteignait pas — pilotage `isPlaying` via events natifs `onPlay`/`onPause` dans `AudioGuide.tsx` (cette session, à committer).
 
-#### 🗺️ **Compteur en haut de la carte **
-- [ ] **Compteur "X Visité, Y À découvrir"** : Style parchemin vintage en haut de la page Carte
-- [ ] **Boutons "Localisation" et "Ambiance"** : Style cohérent avec le compteur et les bouger en haut
-- [ ] **Intégration harmonieuse** : Même esthétique que le design system
+---
 
-#### 🎨 **Marqueurs de carte améliorés**
-- [ ] **Rose des vents miniature** : Remplacer les cercles par des boussoles (bleu si visité, gris sinon)
-<!-- - [ ] **Coffre au trésor** : Pour les lieux spéciaux ou événements importants / concerts ? -->
-<!-- - [ ] **Pin stylisé** : Version "carte ancienne" du marqueur classique -->
-<!-- - [ ] **Animation subtile** : Hover et états actifs avec transitions douces -->
+## 🔥 Priorité 1 — Gestion des données / Données manquantes
 
-#### 🏛️ **Fenêtres modales améliorées**
-- [ ] **Rose des vents décorative** : Sous les titres des modales
-- [ ] **Bordures dessinées à la main** : Contour irrégulier autour des modales
-- [ ] **Boutons stylisés** : Sceaux de cire ou étiquettes de papier ancien
-- [ ] **Contraste amélioré** : Meilleure lisibilité du texte sur fond parchemin
-- [ ] **Éléments décoratifs subtils** : Sans nuire à la fonctionnalité
+### Export OpenAgenda
+- **Objectif** : générer un export (CSV/JSON) du programme aux formats attendus par OpenAgenda pour copier-coller rapide.
+- **Pourquoi** : éviter double saisie organisateurs (Google Sheet → OpenAgenda).
+- **Approche technique** :
+  - Lire `dataService.getEvents()` (post-sync Sheets).
+  - Mapper champs internes → schéma OpenAgenda (title, description, dates, location, image, type).
+  - Bouton "Exporter pour OpenAgenda" dans `/admin` ou page dédiée.
+  - Téléchargement client-side (Blob + `<a download>`).
+- **Effort** : ~½ jour.
 
-#### 🌊 **Représentation de l'eau améliorée**
-- [ ] **Motifs de vagues traditionnels** : Dessinés à la main pour les zones d'eau
-- [ ] **Lavis bleu aquarelle** : Avec fines lignes de vagues
-- [ ] **Style "carte ancienne"** : Intégration harmonieuse avec l'esthétique générale
+### Images événements principaux
+- **Objectif** : 5–10 photos phares (concerts/expos), 400×300px, <50KB.
+- **Pourquoi** : page programme / cartes événements actuellement texte-only ou placeholders.
+- **Stockage** : `public/images/events/<event-id>.jpg`. Référencer via `event.image` (déjà supporté côté type ?).
+- **À vérifier** : `Event` type a-t-il un champ `image`. Si non, ajouter + fallback locationImage.
+- **Effort** : 1h code + dépend de la livraison des visuels.
 
-#### ✨ **Éléments décoratifs subtils**
-- [ ] **Rose des vents détaillée** : Dans un coin de la carte principale
-- [ ] **Bordures vieillis** : Taches de thé et bords déchirés
-- [ ] **Motifs de lignes délicats** : Encadrement des zones importantes
-- [ ] **Illustrations nautiques** : Ancres, navires, dans les espaces vides
-- [ ] **Cadres décoratifs** : Pour mettre en valeur le contenu important
+---
 
-## Améliorations en réflexion
+## 🐛 Priorité 1 — Bugs UX
+
+### ✅ Bouton bruitage — reclic ne s'éteint pas
+- **Statut** : FIXÉ cette session. À committer + PR.
+- **Cause** : `togglePlayPause` toggle React state immédiatement, sans écouter events natifs `play`/`pause`. Promise `audio.play()` en vol pouvait désynchroniser état UI vs élément audio.
+- **Fix** : `isPlaying` piloté par `onPlay`/`onPause` listeners HTML5, togglePlayPause se contente d'appeler `play()`/`pause()` selon `audio.paused`.
+
+### Surcharge boutons header lieu (étude faite)
+- **Symptôme** : header de `LocationDetailsModern` contient 5 boutons d'action côte à côte (Like, Visité, Témoignage, Share, Close) + badge "Bâtiment fermé" parfois. Sur mobile <375px, débordement.
+- **Options évaluées** :
+  1. **Menu kebab (⋮) regroupant secondaires** — Recommandé. Garde Like + Visité + Close visibles, masque Témoignage + Share dans dropdown. Préserve esthétique.
+  2. Réduire à `h-8 w-8` — quick win mais nuit accessibilité tactile (cible <44px).
+  3. Déplacer Témoignage + Share dans une "action bar" en pied de modal — plus de place mais nécessite refonte layout.
+  4. Séparer titre/actions sur 2 lignes — simple, économique en code, garde tous les boutons visibles.
+- **Décision** : à valider entre 1 (menu kebab) et 4 (2 lignes).
+- **Fichier** : `src/components/LocationDetailsModern.tsx:199-280`.
+- **Effort** : 2h.
+
+---
+
+## 🗺️ Priorité 2 — Carte au Trésor (refonte visuelle)
+
+### Compteur "X Visité, Y À découvrir" — style parchemin (étude faite)
+- **État actuel** : `MapHeader.tsx` a déjà la structure (badge double `Visité | À découvrir` avec gradient brun sur la partie droite, bordure `rgba(139,69,19,0.3)`).
+- **Manque** :
+  - Texture parchemin réelle (utiliser `IMAGE_PATHS.BACKGROUNDS.PARCHMENT` en `background-image` sur partie gauche, semi-transparent).
+  - Bordure déchirée / ondulée (SVG `<path>` ou `clip-path: polygon(...)`).
+  - Typo serif plus appuyée (`font-lora` + italique pour "Visité"/"À découvrir").
+  - Optionnel : sceau de cire (PNG/SVG) en accroche centrale séparant les deux moitiés.
+- **Fichier** : `src/components/MapHeader.tsx:30-67`.
+- **Effort** : 2–3h pour version raffinée.
+
+### Boutons "Localisation" et "Ambiance" en haut
+- **État actuel** : déjà en haut dans `MapHeader.tsx:71-103` sous le compteur. IDEES disait "les bouger en haut" — déjà fait, peut-être obsolète. À confirmer avec mockup.
+- **Refinement possible** : style cohérent avec compteur (même bordure parchemin, même gradient).
+
+### Marqueurs de carte améliorés
+- **Rose des vents miniature** au lieu de cercles : SVG 32×32 ; bleu si visité, gris sinon. Remplacer cercles dans le marker layer de la carte.
+- **À localiser** : composant qui rend les markers (probablement dans `Map.tsx`).
+
+### Fenêtres modales décorées
+- Rose des vents sous titres
+- Bordures dessinées à la main (SVG border-image)
+- Boutons style sceau de cire
+- Améliorer contraste texte sur parchemin
+
+### Eau & décor
+- Motifs de vagues SVG dans zones d'eau du fond carte
+- Lavis bleu aquarelle (gradient + texture noise)
+- Rose des vents détaillée en coin (décor)
+- Bordures vieillies (taches thé, bords déchirés)
+- Illustrations nautiques (ancres, navires) dans espaces vides
+
+---
+
+## 🚀 Priorité 3 — Évolutions stratégiques
 
 ### Navigation par chemins praticables
-
-- Implémentation d'un système de waypoints pour représenter les chemins réels sur l'île Feydeau
-- Algorithme A\* pour calculer les itinéraires optimaux en suivant les rues et chemins
-- Interface utilisateur permettant de basculer entre navigation simple et navigation avancée
-- Visualisation des intersections et des points de passage sur la carte
+- Système de waypoints représentant rues réelles île Feydeau.
+- Algorithme A* sur graphe des chemins.
+- Toggle UI navigation simple vs avancée.
+- Visualisation intersections.
 
 ### Gamification
+**Éducatif**
+- Quiz histoire île Feydeau
+- Chasse au trésor
 
-- **Éléments éducatifs**
+**Achievements**
+- Implémenter `ALL_LOCATIONS_VISITED` dans `markLocationAsVisited`
+- Page dédiée achievements
+- Nouveaux : premier lieu, 50% lieux, week-end complet
+- Liés aux événements : concerts, expos, collection complète
+- Liés à l'engagement : partages, feedback
 
-  - Quiz sur l'histoire de l'Île Feydeau
-  - Chasse au trésor
+**Progression**
+- Niveaux : Débutant → Explorateur → Guide → Expert
+- Barre de progression
+- Badges débloquables
+- Classements anonymisés
+- Partage réseaux sociaux
 
-- **Système d'achievements**
+**UX**
+- Notifications visuelles améliorées
+- Journal d'activité / historique
+- Stats perso (visites, temps passé)
 
-  - Implémenter ALL_LOCATIONS_VISITED dans markLocationAsVisited
-  - Créer une page dédiée aux achievements
-  - Nouveaux achievements liés à l'exploration (premier lieu, 50% des lieux, week-end)
-  - Nouveaux achievements liés aux événements (concerts, expositions, collection complète)
-  - Nouveaux achievements liés à l'engagement (partages, feedback)
+**Tech**
+- Enrichir service achievements existant
+- Service progression
+- Hooks suivi actions
 
-- **Progression et récompenses**
+---
 
-  - Système de niveaux utilisateur (Débutant → Explorateur → Guide → Expert)
-  - Barre de progression visuelle
-  - Badges personnalisés débloquables
-  - Classements anonymisés des explorateurs
-  - Partage des réalisations sur réseaux sociaux
+## 🔧 Dette technique / Hygiène repo
 
-- **Expérience utilisateur**
-
-  - Notifications visuelles améliorées pour les achievements
-  - Journal d'activité et historique des réalisations
-  - Statistiques personnelles (visites, temps passé, etc.)
-
-- **Implémentation technique**
-  - Enrichissement du service d'achievements
-  - Création d'un service de progression
-  - Amélioration de l'interface utilisateur
-  - Mise en place de hooks de suivi des actions
+- **Line endings CRLF** dans `package.json`, etc. — polluent diffs. Fix : `.gitattributes` `* text=auto eol=lf` + renormalize.
+- **`setInterval` polling Sheets jamais clear** dans `DataService.constructor` — bénin car singleton, à nettoyer si refacto.
+- **GH `gh pr create`** échoue (collaborator perms manquantes pour le user git local). PRs créées via lien web pour l'instant.

--- a/src/components/AudioGuide.tsx
+++ b/src/components/AudioGuide.tsx
@@ -20,15 +20,16 @@ export const AudioGuide = ({ audioSrc, locationId, className = "" }: AudioGuideP
   const [audioLoading, setAudioLoading] = useState(false);
 
   const togglePlayPause = () => {
-    if (audioRef.current) {
-      if (isPlaying) {
-        audioRef.current.pause();
-        analytics.trackAudio('pause', locationId);
-      } else {
-        audioRef.current.play();
-        analytics.trackAudio('play', locationId);
-      }
-      setIsPlaying(!isPlaying);
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (audio.paused) {
+      audio.play().catch(() => {
+        setIsPlaying(false);
+      });
+      analytics.trackAudio('play', locationId);
+    } else {
+      audio.pause();
+      analytics.trackAudio('pause', locationId);
     }
   };
 
@@ -113,6 +114,8 @@ export const AudioGuide = ({ audioSrc, locationId, className = "" }: AudioGuideP
           : ''}
         onTimeUpdate={handleTimeUpdate}
         onLoadedMetadata={handleLoadedMetadata}
+        onPlay={() => setIsPlaying(true)}
+        onPause={() => setIsPlaying(false)}
         onEnded={() => setIsPlaying(false)}
         onCanPlay={() => setAudioLoading(false)}
         onError={() => setAudioLoading(false)}


### PR DESCRIPTION
## Summary

- Fix audio guide button stuck in "playing" state after second click.
- Restructure `docs/IDEES.md` into a priorities-first ROADMAP.

## Why

User reported the bruitage button did not turn off on re-click. Root cause: `togglePlayPause` in `src/components/AudioGuide.tsx` toggled the React `isPlaying` state immediately based on the previous value. Since `audio.play()` is async, a failed/rejected play, a natural pause, or an end event left React state out of sync with the real `<audio>` element. Re-click then triggered the wrong branch.

## Changes

### `src/components/AudioGuide.tsx`
- `togglePlayPause` reads `audio.paused` as source of truth, calls `play()` / `pause()` only.
- `isPlaying` is now driven by the `<audio>` element via `onPlay` / `onPause`.
- `play().catch` falls back to `setIsPlaying(false)` on rejection.

### `docs/IDEES.md` → ROADMAP
- "Récemment livré" section (incl. Google Sheets sync, photo fix, MP3s).
- P1 Données : Export OpenAgenda, images événements phares.
- P1 Bugs : audio toggle (this PR), study of overcrowded `LocationDetailsModern` header (recommends kebab menu).
- P2 Carte au Trésor : study of parchment counter refinements on `MapHeader.tsx`.
- P3 Strategic : navigation par chemins, gamification.
- Tech debt : CRLF in package.json, uncleared setInterval in DataService.

## Test plan

- [ ] Open a "Histoire des lieux" page with audio.
- [ ] Click play, verify pause icon shows.
- [ ] Click again, verify it pauses and the icon switches back to play.
- [ ] Click rapidly, verify no stuck "playing" state.
- [ ] Let track end naturally, verify button shows play (not pause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)