### PR TITLE
ci: fix deploy Vercel + test parseCSVLine

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -45,6 +45,8 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      # Le CLI Vercel lit automatiquement VERCEL_TOKEN depuis l'env.
+      VERCEL_TOKEN: ${{ secrets.COLL_VERCEL_TOKEN }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v4
@@ -60,8 +62,8 @@ jobs:
 
       - name: 🚀 Deploy to Vercel (production)
         if: github.ref == 'refs/heads/main'
-        run: npx vercel --prod --token ${{ secrets.VERCEL_TOKEN }} --yes
+        run: npx vercel --prod --yes
 
       - name: 🔎 Deploy to Vercel (preview)
         if: github.ref == 'refs/heads/staging'
-        run: npx vercel --token ${{ secrets.VERCEL_TOKEN }} --yes
+        run: npx vercel --yes

--- a/src/services/importExportService.test.ts
+++ b/src/services/importExportService.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { parseCSVLine } from "./importExportService";
+
+describe("parseCSVLine", () => {
+  it("découpe une ligne simple", () => {
+    expect(parseCSVLine("a,b,c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("ignore les virgules à l'intérieur de guillemets", () => {
+    expect(parseCSVLine('"Artist, Inc.",x')).toEqual(["Artist, Inc.", "x"]);
+  });
+
+  it("gère les guillemets échappés ('' devient \")", () => {
+    expect(parseCSVLine('"il dit ""salut""",fin')).toEqual([
+      'il dit "salut"',
+      "fin",
+    ]);
+  });
+
+  it("préserve les champs vides", () => {
+    expect(parseCSVLine("a,,c")).toEqual(["a", "", "c"]);
+  });
+
+  it("préserve un champ vide en fin de ligne (virgule finale)", () => {
+    expect(parseCSVLine("a,b,")).toEqual(["a", "b", ""]);
+  });
+
+  it("retourne un seul champ vide pour une ligne vide", () => {
+    expect(parseCSVLine("")).toEqual([""]);
+  });
+
+  it("gère un mix de champs quotés et non quotés", () => {
+    expect(parseCSVLine('1,"deux, 2",trois')).toEqual(["1", "deux, 2", "trois"]);
+  });
+});

--- a/src/services/importExportService.ts
+++ b/src/services/importExportService.ts
@@ -27,6 +27,44 @@ export interface ImportResult {
 const EXPORT_VERSION = "1.0.0";
 
 /**
+ * Parse une ligne CSV en tableau de valeurs en tenant compte des guillemets.
+ * - Les virgules à l'intérieur de guillemets ne séparent pas les champs.
+ * - Les guillemets doublés ("") à l'intérieur d'un champ quoté sont un guillemet littéral.
+ */
+export const parseCSVLine = (line: string): string[] => {
+  const values: string[] = [];
+  let currentValue = '';
+  let insideQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === '"') {
+      // Deux guillemets consécutifs à l'intérieur d'une chaîne entre guillemets
+      if (insideQuotes && i + 1 < line.length && line[i + 1] === '"') {
+        currentValue += '"';
+        i++; // Sauter le prochain guillemet
+      } else {
+        // Basculer l'état "à l'intérieur des guillemets"
+        insideQuotes = !insideQuotes;
+      }
+    } else if (char === ',' && !insideQuotes) {
+      // Fin d'une valeur
+      values.push(currentValue);
+      currentValue = '';
+    } else {
+      // Ajouter le caractère à la valeur actuelle
+      currentValue += char;
+    }
+  }
+
+  // Ajouter la dernière valeur
+  values.push(currentValue);
+
+  return values;
+};
+
+/**
  * Exporte toutes les données de l'application au format JSON
  */
 export const exportAllData = (): string => {
@@ -374,40 +412,6 @@ export const importEventsFromCSV = (csvData: string): ImportResult => {
         errors: [`En-têtes manquants: ${missingHeaders.join(', ')}`]
       };
     }
-    
-    // Fonction pour parser une ligne CSV en tenant compte des guillemets
-    const parseCSVLine = (line: string): string[] => {
-      const values: string[] = [];
-      let currentValue = '';
-      let insideQuotes = false;
-      
-      for (let i = 0; i < line.length; i++) {
-        const char = line[i];
-        
-        if (char === '"') {
-          // Si nous avons deux guillemets consécutifs à l'intérieur d'une chaîne entre guillemets
-          if (insideQuotes && i + 1 < line.length && line[i + 1] === '"') {
-            currentValue += '"';
-            i++; // Sauter le prochain guillemet
-          } else {
-            // Basculer l'état "à l'intérieur des guillemets"
-            insideQuotes = !insideQuotes;
-          }
-        } else if (char === ',' && !insideQuotes) {
-          // Fin d'une valeur
-          values.push(currentValue);
-          currentValue = '';
-        } else {
-          // Ajouter le caractère à la valeur actuelle
-          currentValue += char;
-        }
-      }
-      
-      // Ajouter la dernière valeur
-      values.push(currentValue);
-      
-      return values;
-    };
     
     // Convertir les lignes en événements
     const events: Event[] = [];


### PR DESCRIPTION
## Deploy fix (point 4)
Le run prod du merge #6 a echoue : le secret s'appelle `COLL_VERCEL_TOKEN`, pas `VERCEL_TOKEN`, donc `--token` recevait une valeur vide et crashait le CLI. Fix: token passe via env `VERCEL_TOKEN` (lu auto par le CLI), commandes simplifiees en `npx vercel --prod --yes` / `npx vercel --yes`.

## parseCSVLine (point 3)
Extrait la closure interne `parseCSVLine` au niveau module + export (comportement inchange). Nouveau test `importExportService.test.ts` : virgules quotees, guillemets echappes (`""`), champs vides, ligne vide, mix.

## Etat
- `npm test` -> 47 verts. `npm run typecheck` -> 0 erreur.

## Verif post-merge
- Run prod sur `main` doit atteindre l'etape Vercel et deployer (plus de crash `--token`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)