### PR TITLE
Mettre à jour la date sur la page d'accueil en 2026

### DIFF
--- a/src/pages/SplashScreen.tsx
+++ b/src/pages/SplashScreen.tsx
@@ -70,7 +70,7 @@ const SplashScreen = ({ onComplete }: SplashScreenProps) => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.5, duration: 0.5 }}
         >
-          1 Hall 1 Artiste 2025
+          1 Hall 1 Artiste 2026
         </motion.h1>
         <motion.img 
           src={getImagePath('/Logo.png')} 


### PR DESCRIPTION
## Résumé

Mise à jour de la date affichée sur la page d'accueil (écran de démarrage) de « 1 Hall 1 Artiste 2025 » vers « 1 Hall 1 Artiste 2026 ».

## Changement

- `src/pages/SplashScreen.tsx` : titre passé à « 1 Hall 1 Artiste 2026 »

## Note

Le fichier `public/offline.html` contient aussi une mention « © 2025 » dans le pied de page. Je ne l'ai pas modifié car il s'agit d'un copyright et non de l'année de l'édition, mais je peux le mettre à jour si souhaité.

https://claude.ai/code/session_01MxuYhQ3iNuS4Undis8uQNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxuYhQ3iNuS4Undis8uQNM)_