### PR TITLE
Corriger les erreurs ESLint no-useless-escape dans les routes API

### DIFF
--- a/api/community.ts
+++ b/api/community.ts
@@ -59,7 +59,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       if (!process.env.MODERATION_SECRET || key !== process.env.MODERATION_SECRET) {
         return res.status(401).json({ error: "Non autorisé" });
       }
-      const id = String((req.query.id as string) || (req.body as { id?: string })?.id || "").replace(/[.#$/\[\]]/g, "");
+      const id = String((req.query.id as string) || (req.body as { id?: string })?.id || "").replace(/[.#$/[\]]/g, "");
       if (!id) return res.status(400).json({ error: "id requis" });
       await rtdbDelete(`${PATH}/${id}`);
       return res.status(200).json({ ok: true });

--- a/api/likes.ts
+++ b/api/likes.ts
@@ -7,7 +7,7 @@ import { rtdbGet, rtdbPut } from "./_firebase.js";
 const LIKES_PATH = "likes-data";
 
 function sanitizeId(v: unknown): string {
-  return String(v || "").replace(/[.#$/\[\]]/g, "").slice(0, 200);
+  return String(v || "").replace(/[.#$/[\]]/g, "").slice(0, 200);
 }
 
 async function updateGlobalStats(): Promise<void> {


### PR DESCRIPTION
## Résumé

Correction des erreurs ESLint `no-useless-escape` qui faisaient échouer le check « 🧪 Tests » sur le CI.

Dans les classes de caractères des expressions régulières, le crochet ouvrant `[` n'a pas besoin d'être échappé. Le motif `/[.#$/\[\]]/g` devient `/[.#$/[\]]/g` (le `\]` reste nécessaire). Le comportement de la regex est strictement identique.

## Changements

- `api/community.ts:62` — suppression de l'échappement inutile `\[`
- `api/likes.ts:10` — suppression de l'échappement inutile `\[`

## Vérification

- `npm run lint` passe sans erreur en local

https://claude.ai/code/session_01MxuYhQ3iNuS4Undis8uQNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxuYhQ3iNuS4Undis8uQNM)_