### PR TITLE
Calcul automatique de l'année et des dates du festival

### DIFF
--- a/src/pages/SplashScreen.tsx
+++ b/src/pages/SplashScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { getImagePath } from "@/utils/imagePaths";
+import { getFestivalYear } from "@/utils/festival";
 
 interface SplashScreenProps {
   onComplete: () => void;
@@ -70,7 +71,7 @@ const SplashScreen = ({ onComplete }: SplashScreenProps) => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.5, duration: 0.5 }}
         >
-          1 Hall 1 Artiste 2026
+          1 Hall 1 Artiste {getFestivalYear()}
         </motion.h1>
         <motion.img 
           src={getImagePath('/Logo.png')} 

--- a/src/services/importExportService.ts
+++ b/src/services/importExportService.ts
@@ -1,6 +1,7 @@
 import { Event } from "@/data/events";
 import { Location } from "@/data/locations";
 import { createLogger } from "@/utils/logger";
+import { getFestivalDates } from "@/utils/festival";
 import { dataService } from "./dataService";
 import { validateEvent, validateLocation } from "./validationService";
 
@@ -188,11 +189,8 @@ export const exportEventsToCSV = (): string => {
   }
 };
 
-// Dates du festival (troisième week-end de septembre 2026)
-const FESTIVAL_DATES: Record<string, string> = {
-  samedi: '2026-09-19',
-  dimanche: '2026-09-20',
-};
+// Dates du festival (troisième week-end de septembre), calculées automatiquement.
+const FESTIVAL_DATES: Record<string, string> = getFestivalDates();
 const FESTIVAL_TIMEZONE = '+02:00';
 
 function parseEventTime(timeStr: string): { start: string; end: string } | null {

--- a/src/utils/festival.ts
+++ b/src/utils/festival.ts
@@ -1,0 +1,38 @@
+// Calcule automatiquement l'année et les dates du festival.
+// Le festival a lieu le 3ᵉ week-end (samedi/dimanche) de septembre.
+// L'année de l'édition suit l'année calendaire en cours (new Date().getFullYear()).
+
+// Année de l'édition courante.
+export function getFestivalYear(now: Date = new Date()): number {
+  return now.getFullYear();
+}
+
+// Renvoie le samedi du 3ᵉ week-end de septembre pour une année donnée.
+function thirdSeptemberSaturday(year: number): Date {
+  // 1er septembre de l'année.
+  const firstOfSeptember = new Date(year, 8, 1);
+  const dayOfWeek = firstOfSeptember.getDay(); // 0 = dimanche, 6 = samedi
+  // Décalage vers le premier samedi de septembre.
+  const offsetToFirstSaturday = (6 - dayOfWeek + 7) % 7;
+  const firstSaturday = 1 + offsetToFirstSaturday;
+  // Le 3ᵉ samedi = premier samedi + 2 semaines.
+  return new Date(year, 8, firstSaturday + 14);
+}
+
+function formatISODate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+// Dates (format YYYY-MM-DD) du week-end de festival pour l'année courante.
+export function getFestivalDates(now: Date = new Date()): { samedi: string; dimanche: string } {
+  const saturday = thirdSeptemberSaturday(getFestivalYear(now));
+  const sunday = new Date(saturday);
+  sunday.setDate(saturday.getDate() + 1);
+  return {
+    samedi: formatISODate(saturday),
+    dimanche: formatISODate(sunday),
+  };
+}


### PR DESCRIPTION
## Objectif

Éviter de mettre à jour les années en dur (2026, 2025, …) à chaque édition. Les valeurs fonctionnelles sont désormais calculées automatiquement.

## Ce qui est centralisé

Nouveau fichier `src/utils/festival.ts` :
- `getFestivalYear()` → suit l'**année calendaire en cours** (`new Date().getFullYear()`).
- `getFestivalDates()` → calcule le **3ᵉ week-end de septembre** (samedi + dimanche) au format `YYYY-MM-DD`.

## Branchements

| Fichier | Avant | Après |
|---|---|---|
| `src/pages/SplashScreen.tsx` | `1 Hall 1 Artiste 2026` | `1 Hall 1 Artiste {getFestivalYear()}` |
| `src/services/importExportService.ts` | dates codées en dur `2026-09-19` / `2026-09-20` | `getFestivalDates()` |

## Vérification

Le calcul du 3ᵉ week-end reproduit exactement l'ancienne valeur codée en dur :

| Année | Samedi | Dimanche |
|---|---|---|
| 2024 | 2024-09-21 | 2024-09-22 |
| 2025 | 2025-09-20 | 2025-09-21 |
| **2026** | **2026-09-19** | **2026-09-20** |
| 2027 | 2027-09-18 | 2027-09-19 |

## Hors périmètre (volontairement non modifié)

- Années de **fondation** : `about.ts` / `association.ts` (`2017`).
- Contenus/archives liés à une édition précise : workflow `publish-2026.yml`, docs `ADMIN-2026-*`, CSV, `CHANGELOG.md`, `README.md`.

https://claude.ai/code/session_01KvHRCZ2wcKHH6EQHKBYKY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvHRCZ2wcKHH6EQHKBYKY6)_