### PR TITLE
chore: couper les logs verbeux en production

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import './utils/productionConsole'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'

--- a/src/utils/productionConsole.ts
+++ b/src/utils/productionConsole.ts
@@ -1,0 +1,20 @@
+/**
+ * Garde-fou des logs en production.
+ *
+ * En production, on neutralise les logs verbeux (console.log / info / debug)
+ * afin de ne pas exposer les logs internes de l'application dans la console
+ * des visiteurs. Les avertissements et erreurs (console.warn / console.error)
+ * sont volontairement conservés pour le diagnostic.
+ *
+ * Ce module est importé en tout premier dans main.tsx pour s'appliquer avant
+ * l'exécution du reste de l'application (y compris les logs émis au chargement
+ * des modules et ceux passant par utils/logger.ts, qui s'appuie sur console.log).
+ */
+if (import.meta.env.PROD) {
+  const noop = (..._args: unknown[]): void => {};
+  console.log = noop;
+  console.info = noop;
+  console.debug = noop;
+}
+
+export {};


### PR DESCRIPTION
## Objectif

Couper les logs verbeux en **production** (Piste 1A de la revue). Aujourd'hui, les `console.log` internes — qu'ils soient des 268 appels directs ou ceux passant par `utils/logger.ts` (qui utilise `console.log` en dessous) — s'affichent dans la console des visiteurs en prod, car le logger n'a aucun garde-fou prod/dev.

## Changement

- Ajout de `src/utils/productionConsole.ts` : quand `import.meta.env.PROD`, neutralise `console.log` / `console.info` / `console.debug`. **`console.warn` et `console.error` sont conservés** pour le diagnostic.
- Importé **en tout premier** dans `main.tsx`, donc il s'applique avant le reste de l'app (y compris les logs émis au chargement des modules).

Approche volontairement minimale : **un seul point de contrôle** plutôt que la réécriture fastidieuse des ~268 appels `console.*`. En développement, comportement inchangé.

## Validation locale
- `npm run typecheck` ✓ (0 erreur)
- `npm run lint` ✓ (0 erreur)
- `npx vitest run` ✓ (47 tests)
- `npm run build` ✓ (build de prod réussi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3NAL3JVHuQMwopS5yG5g2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3NAL3JVHuQMwopS5yG5g2)_