### PR TITLE
fix(lint): erreur no-useless-escape qui bloquait la CI

### DIFF
--- a/api/_visit-db.ts
+++ b/api/_visit-db.ts
@@ -24,7 +24,7 @@ function generateId(): string {
 // so percent-encoding doesn't help). Replace illegal chars with ',' (legal). '@' is OK.
 // Index-only key — real email lives in the doc — so collisions are harmless.
 export function emailKey(email: string): string {
-  return email.toLowerCase().replace(/[.#$\[\]/]/g, ",");
+  return email.toLowerCase().replace(/[.#$[\]/]/g, ",");
 }
 
 // ============ TOURS ============


### PR DESCRIPTION
`api/_visit-db.ts` avait `\[` dans une classe de caractères regex → erreur `no-useless-escape`, bloquait la CI sur main depuis plusieurs commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)