### PR TITLE
fix: keep bottom-right brush icon size constant across filters

### DIFF
--- a/src/pages/Program.tsx
+++ b/src/pages/Program.tsx
@@ -169,15 +169,13 @@ const Program = () => {
       <div className="brush-stroke-left"></div>
       <div className="brush-stroke-left-2"></div>
 
-      {/* Pinceaux pour expositions OU Clé de sol pour concerts en bas à droite */}
-      <div 
-        className="fixed bottom-14 right-0 pointer-events-none z-20 transition-all duration-500"
+      {/* Pinceaux en bas à droite */}
+      <div
+        className="fixed bottom-14 right-0 pointer-events-none z-20"
         style={{
-          width: currentFilter.toLowerCase().includes('concert') ? '75px' : '201px',
-          height: currentFilter.toLowerCase().includes('concert') ? '210px' : '259px',
-          backgroundImage: currentFilter === 'concert' 
-            ? `url('${getImagePath('/images/Petite Clef 50.png')}')`
-            : `url('${getImagePath('/images/Pinceaux.png')}')`,
+          width: '201px',
+          height: '259px',
+          backgroundImage: `url('${getImagePath('/images/Pinceaux.png')}')`,
           backgroundSize: 'contain',
           backgroundRepeat: 'no-repeat',
           backgroundPosition: 'bottom right'


### PR DESCRIPTION
## Summary
- The bottom-right decorative icon on the Programme page swapped image and dimensions (Pinceaux.png 201x259 vs Petite Clef 50.png 75x210) whenever the Concert filter was active, causing a visible resize/pop.
- Removed the concert-specific branching; the brush icon (Pinceaux.png) now renders at a fixed 201x259 regardless of active filter.

## Test plan
- [x] Ran dev server, opened Programme page, toggled between Exposition/Concert/Atelier/Escape Game filters
- [x] Confirmed icon stays Pinceaux.png at fixed 201x259 across all filters (verified via DOM inspection)